### PR TITLE
Fix __init__.py exports and update docstring

### DIFF
--- a/src/shardate/__init__.py
+++ b/src/shardate/__init__.py
@@ -1,9 +1,5 @@
-"""Carve: Fast reader for YMD-partitioned Parquet files."""
+"""Shardate: Fast reader for YMD-partitioned Parquet files."""
 
 from shardate.read import read_between, read_by_date, read_by_dates
 
-all = [
-    "read_between",
-    "read_by_date",
-    "read_by_dates",
-]
+__all__ = ["read_between", "read_by_date", "read_by_dates"]


### PR DESCRIPTION
This pull request makes a minor update to the `src/shardate/__init__.py` file to improve clarity and correctness in the module's documentation and export mechanism.

* Updated the module docstring to use the correct project name (`Shardate` instead of `Carve`).
* Changed the export statement from `all` to the proper Python convention `__all__`, ensuring that only the intended functions are exposed when importing the module.