### PR TITLE
Add GitHub Action for PyPI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Install dependencies
+      run: uv sync --dev
+
+    - name: Build package
+      run: uv build
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verify-metadata: false


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate package releases to PyPI. The workflow is triggered when a release is published and handles environment setup, dependency installation, building the package, and publishing to PyPI.

Release automation:

* Added `.github/workflows/release.yml` to define a workflow that triggers on release publication and deploys the package to PyPI using trusted publishing.
* Configured steps for Python 3.12 setup, dependency installation with `uv`, package building, and PyPI publishing via `pypa/gh-action-pypi-publish`.