### PR TITLE
doc: rename carve -> shardate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# carve
+# shardate
 
 A lightweight Python library for efficiently reading year-month-day partitioned Parquet datasets with PySpark.
 
 ## Installation
 
 ```bash
-pip install carve
+pip install shardate
 ```
 
 ## Features
@@ -19,7 +19,7 @@ pip install carve
 
 ```python
 from datetime import date
-from carve import read_by_date, read_between, read_by_dates
+from shardate import read_by_date, read_between, read_by_dates
 
 # Read data for a specific date
 df = read_by_date("/path/to/data", date(2025, 1, 15))


### PR DESCRIPTION
This pull request updates the project name throughout the documentation to reflect a rebranding from "carve" to "shardate". The most important changes are:

Documentation updates:

* Changed the project name in the `README.md` header from `carve` to `shardate`.
* Updated installation instructions in `README.md` to use `pip install shardate` instead of `pip install carve`.
* Modified code examples in `README.md` to import functions from `shardate` rather than `carve`.