### PR TITLE
feat: add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+lint:
+	uv run ruff check --fix .
+	uv run ruff format .
+	
+clean:
+	rm -rf .mypy_cache
+	rm -rf build
+	rm -rf dist
+	rm -rf *.egg-info
+	rm -rf .pytest_cache
+	rm -rf artifacts
+	rm -rf .ruff_cache
+	rm -rf .venv
+	rm -f uv.lock
+	find . -name '__pycache__' -exec rm -rf {} +
+
+build:
+	uv run python -m build
+
+publish:
+	uv run twine upload dist/*
+
+publish-test:
+	uv run twine upload --repository testpypi dist/*


### PR DESCRIPTION
This pull request adds several new utility targets to the `Makefile` to streamline common development tasks, including linting, cleaning, building, and publishing the project.

Development workflow improvements:

* Added a `lint` target to automatically run code checks and formatting using `ruff`.
* Added a `clean` target to remove build artifacts, caches, virtual environments, and lock files, helping keep the workspace tidy.
* Added a `build` target to build the project using Python's build module.
* Added `publish` and `publish-test` targets to upload distributions to PyPI and TestPyPI respectively using `twine`.