### PR TITLE
feat: add test and build to publish's dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ clean:
 build:
 	uv run python -m build
 
-publish:
+publish: build
 	uv run twine upload dist/*
 
 publish-test:
 	uv run twine upload --repository testpypi dist/*
+
+test:
+	uv run pytest -vvv


### PR DESCRIPTION
This pull request updates the `Makefile` to improve the workflow for building, publishing, and testing the project. The most important changes are grouped below:

Build and publish workflow improvements:

* The `publish` target now depends on the `build` target, ensuring the project is built before publishing.

Testing enhancements:

* Added a new `test` target to run tests using `pytest` with verbose output.