### PR TITLE
fix: correct repository URLs in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yoichiojima-2/carve"
-Repository = "https://github.com/yoichiojima-2/carve"
-Issues = "https://github.com/yoichiojima-2/carve/issues"
+Homepage = "https://github.com/yoichiojima-2/shardate"
+Repository = "https://github.com/yoichiojima-2/shardate"
+Issues = "https://github.com/yoichiojima-2/shardate/issues"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Fixes #12

The publish workflow was failing because the project URLs in pyproject.toml were pointing to the wrong repository (carve instead of shardate). This fix updates the URLs to point to the correct repository.

Generated with [Claude Code](https://claude.ai/code)