### PR TITLE
fix: add __version__ attribute to package init

### DIFF
--- a/src/shardate/__init__.py
+++ b/src/shardate/__init__.py
@@ -2,4 +2,5 @@
 
 from shardate.read import read_between, read_by_date, read_by_dates
 
+__version__ = "2025.9.8"
 __all__ = ["read_between", "read_by_date", "read_by_dates"]


### PR DESCRIPTION
Fixes #15

Adds __version__ attribute to the package __init__.py file to fix the CI/CD release issue. This ensures the version is properly accessible for PyPI publishing tools.

Generated with [Claude Code](https://claude.ai/code)