### PR TITLE
release: v2025.9.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shardate"
-version = "2025.9.8"
+version = "2025.9.8.1"
 description = "A lightweight Python library for efficiently reading year-month-day partitioned Parquet datasets."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/shardate/__init__.py
+++ b/src/shardate/__init__.py
@@ -1,6 +1,12 @@
 """Shardate: Fast reader for YMD-partitioned Parquet files."""
 
+import importlib.metadata
+
 from shardate.read import read_between, read_by_date, read_by_dates
 
-__version__ = "2025.9.8"
+try:
+    __version__ = importlib.metadata.version("shardate")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
 __all__ = ["read_between", "read_by_date", "read_by_dates"]


### PR DESCRIPTION
This pull request updates the library versioning scheme and improves how the `__version__` attribute is set in `shardate`. The main changes are related to package metadata and initialization.

**Versioning and metadata improvements:**

* Updated the version number in `pyproject.toml` from `2025.9.8` to `2025.9.8.1` to reflect a patch release.
* Changed the way `__version__` is set in `src/shardate/__init__.py` to dynamically retrieve the version using `importlib.metadata`, with a fallback to `"unknown"` if the package is not installed. This makes the version attribute more robust and consistent with modern Python packaging practices.