### PR TITLE
fix: test-publish (makefile)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ __marimo__/
 # Project
 artifacts/
 .claude
+uv.lock

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 publish: build
 	uv run twine upload dist/*
 
-publish-test:
+publish-test: build
 	uv run twine upload --repository testpypi dist/*
 
 test:


### PR DESCRIPTION
This pull request makes a small adjustment to the `Makefile` to ensure that the `publish-test` target depends on the `build` step. This change helps prevent issues where the test publish command could run before the package is built.