### PR TITLE
Feat/mypy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,8 @@ jobs:
     - name: Install dependencies
       run: uv sync --dev
     
+    - name: Run types check
+      run: uv run mypy .
+
     - name: Run tests
       run: uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,8 @@ publish: build
 publish-test: build
 	uv run twine upload --repository testpypi dist/*
 
+typecheck:
+	uv run mypy .
+
 test:
 	uv run pytest -vvv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "pytest>=8.4.2",
     "ruff>=0.12.12",
     "twine>=6.2.0",
+    "types-python-dateutil>=2.9.0.20250822",
 ]
 
 [build-system]

--- a/src/shardate/dates.py
+++ b/src/shardate/dates.py
@@ -1,16 +1,17 @@
+from datetime import date
 from dateutil.relativedelta import relativedelta
 
 
-def all_dates_between(start_date, end_date):
+def all_dates_between(start_date: date, end_date: date):
     return (
         start_date + relativedelta(days=i)
         for i in range((end_date - start_date).days + 1)
     )
 
 
-def is_end_of_month(dt):
+def is_end_of_month(dt: date):
     return dt == dt + relativedelta(day=1, months=1, days=-1)
 
 
-def eoms_between(start_date, end_date):
+def eoms_between(start_date: date, end_date: date):
     return [i for i in all_dates_between(start_date, end_date) if is_end_of_month(i)]

--- a/src/shardate/utils.py
+++ b/src/shardate/utils.py
@@ -1,5 +1,6 @@
+from pyspark.sql import Column
 from pyspark.sql import functions as F
 
 
-def date_col():
+def date_col() -> Column:
     return F.to_date(F.concat_ws("-", "y", "m", "d")).alias("date")

--- a/tests/test_shardate.py
+++ b/tests/test_shardate.py
@@ -56,7 +56,7 @@ def path(spark, start_date, end_date, tmp_path_factory):
     return path
 
 
-def _get_dates_in_df(df: DataFrame) -> Iterable[date]:
+def _get_dates_in_df(df: DataFrame) -> list[date]:
     return [row["date"] for row in sorted(df.select(date_col()).distinct().collect())]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -559,6 +559,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "twine" },
+    { name = "types-python-dateutil" },
 ]
 
 [package.metadata]
@@ -574,6 +575,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = ">=0.12.12" },
     { name = "twine", specifier = ">=6.2.0" },
+    { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },
 ]
 
 [[package]]
@@ -603,6 +605,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20250822"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/0a/775f8551665992204c756be326f3575abba58c4a3a52eef9909ef4536428/types_python_dateutil-2.9.0.20250822.tar.gz", hash = "sha256:84c92c34bd8e68b117bff742bc00b692a1e8531262d4507b33afcc9f7716cd53", size = 16084, upload-time = "2025-08-22T03:02:00.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/d9/a29dfa84363e88b053bf85a8b7f212a04f0d7343a4d24933baa45c06e08b/types_python_dateutil-2.9.0.20250822-py3-none-any.whl", hash = "sha256:849d52b737e10a6dc6621d2bd7940ec7c65fcb69e6aa2882acf4e56b2b508ddc", size = 17892, upload-time = "2025-08-22T03:01:59.436Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces improvements to development tooling and type safety, as well as a minor code refactor. The most important changes are grouped below.

**Development tooling enhancements:**

* Added a new `typecheck` target to the `Makefile` to enable running `mypy` for type checking.
* Added `types-python-dateutil` to the development dependencies in `pyproject.toml` to improve type checking for dateutil usage.

**Code refactor for type safety:**

* Changed the return type of `_get_dates_in_df` from `Iterable[date]` to `list[date]` in the newly renamed `tests/test_shardate.py` to better reflect its actual output.
This pull request introduces type annotations across the codebase to improve type safety and developer experience. It also adds type checking to the CI workflow and development tools, and makes minor improvements to utility functions and test code.

**Type annotations and code improvements:**

* Added explicit type annotations to functions in `src/shardate/dates.py`, `src/shardate/shardate.py`, and `src/shardate/utils.py` to clarify expected input and output types. [[1]](diffhunk://#diff-04284df7b5ff409580c18ced3f02a43d8014efc8016085c1eee1d0be9760edf1R1-R16) [[2]](diffhunk://#diff-ecac2cc0591986ed531bbae358a31a0720a6b45c7f6a4f8597146168c5437dfdR1-R14) [[3]](diffhunk://#diff-ecac2cc0591986ed531bbae358a31a0720a6b45c7f6a4f8597146168c5437dfdL19-R47) [[4]](diffhunk://#diff-c61893c5f20d17d2e35c1cc91fa103a83540b243ca40467d62bc57b3b43315b4R1-R5)

**Testing and CI enhancements:**

* Updated `.github/workflows/test.yml` to run `mypy` type checks as part of the CI pipeline.
* Added a `typecheck` target to the `Makefile` for running `mypy`.
* Added `types-python-dateutil` to the development dependencies in `pyproject.toml` to support better type checking.

**Test code improvements:**

* Changed the return type of `_get_dates_in_df` in `tests/test_shardate.py` from `Iterable[date]` to `list[date]` for clarity and consistency.