### PR TITLE
test: add coverage for exception handling

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,27 @@
+"""Tests for shardate.__init__ module."""
+
+import pytest
+from unittest.mock import patch
+import importlib.metadata
+
+
+def test_version_with_package_not_found_error():
+    """Test that __version__ falls back to 'unknown' when package metadata is not found."""
+    with patch('importlib.metadata.version', side_effect=importlib.metadata.PackageNotFoundError):
+        # Re-import the module to trigger the exception handling
+        import importlib
+        import shardate
+        importlib.reload(shardate)
+        
+        assert shardate.__version__ == "unknown"
+
+
+def test_version_with_valid_package():
+    """Test that __version__ is set correctly when package metadata is found."""
+    with patch('importlib.metadata.version', return_value="1.0.0"):
+        # Re-import the module to get the mocked version
+        import importlib
+        import shardate
+        importlib.reload(shardate)
+        
+        assert shardate.__version__ == "1.0.0"

--- a/tests/test_shardate.py
+++ b/tests/test_shardate.py
@@ -5,7 +5,7 @@ import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql import DataFrame
 
-from shardate.shardate import Shardate
+from shardate.shardate import Shardate, spark_session
 from shardate.dates import all_dates_between
 from shardate.utils import date_col
 
@@ -86,3 +86,13 @@ def test_read_eoms_between(path: str, start_date: date, end_date: date):
         dt for dt in all_dates_between(start_date, end_date) if dt.day == 31
     ]
     assert dates == expected_dates
+
+
+def test_spark_session_no_active_session():
+    """Test that spark_session() raises RuntimeError when no active SparkSession is found."""
+    # Stop any existing SparkSession
+    if spark := SparkSession.getActiveSession():
+        spark.stop()
+    
+    with pytest.raises(RuntimeError, match="No active SparkSession found. Please create one."):
+        spark_session()


### PR DESCRIPTION
Added test coverage for exception handling scenarios in `__init__.py` and `shardate.py` that were previously uncovered according to codecov.

**Changes:**
- Created `tests/test_init.py` with tests for `importlib.metadata.PackageNotFoundError`
- Added test in `tests/test_shardate.py` for `RuntimeError` when no SparkSession is active

Fixes #29

Generated with [Claude Code](https://claude.ai/code)