### PR TITLE
test: add coverage for exception handling

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,29 @@
+"""Tests for shardate.__init__ module."""
+import importlib.metadata
+import unittest.mock
+
+import shardate
+
+
+def test_version_with_package_not_found_error():
+    """Test version handling when PackageNotFoundError is raised."""
+    with unittest.mock.patch(
+        'importlib.metadata.version',
+        side_effect=importlib.metadata.PackageNotFoundError()
+    ):
+        # Reload the module to trigger the exception handling
+        import importlib
+        importlib.reload(shardate)
+        assert shardate.__version__ == "unknown"
+
+
+def test_version_with_valid_package():
+    """Test version retrieval when package is found."""
+    with unittest.mock.patch(
+        'importlib.metadata.version',
+        return_value="1.2.3"
+    ):
+        # Reload the module to trigger version retrieval
+        import importlib
+        importlib.reload(shardate)
+        assert shardate.__version__ == "1.2.3"

--- a/tests/test_shardate.py
+++ b/tests/test_shardate.py
@@ -1,11 +1,12 @@
 from datetime import date
 from typing import Iterable
+import unittest.mock
 
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql import DataFrame
 
-from shardate.shardate import Shardate
+from shardate.shardate import Shardate, spark_session
 from shardate.dates import all_dates_between
 from shardate.utils import date_col
 
@@ -86,3 +87,11 @@ def test_read_eoms_between(path: str, start_date: date, end_date: date):
         dt for dt in all_dates_between(start_date, end_date) if dt.day == 31
     ]
     assert dates == expected_dates
+
+
+def test_spark_session_no_active_session():
+    """Test spark_session function raises RuntimeError when no active session."""
+    # Mock SparkSession.getActiveSession to return None
+    with unittest.mock.patch('shardate.shardate.SparkSession.getActiveSession', return_value=None):
+        with pytest.raises(RuntimeError, match="No active SparkSession found. Please create one."):
+            spark_session()


### PR DESCRIPTION
Added test coverage for exception handling scenarios in `__init__.py` and `shardate.py` that were previously uncovered according to codecov.

**Changes:**
- Created `tests/test_init.py` with tests for `importlib.metadata.PackageNotFoundError`
- Added test in `tests/test_shardate.py` for `RuntimeError` when no SparkSession is active

Fixes #29

🤖 Generated with [Claude Code](https://claude.ai/code)