### PR TITLE
Release/v2025.9.20.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "shardate"
 version = "2025.9.20.3"
 description = "A lightweight Python library for efficiently reading year-month-day partitioned Parquet datasets."
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 authors = [
     {name = "Yoichi Ojima", email = "yoichiojima@gmail.com"}
 ]
@@ -16,45 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "build>=1.3.0",
-    "certifi>=2025.8.3",
-    "charset-normalizer>=3.4.3",
-    "coverage>=7.10.6",
-    "docutils>=0.22.1",
-    "id>=1.5.0",
-    "idna>=3.10",
-    "iniconfig>=2.1.0",
-    "jaraco-classes>=3.4.0",
-    "jaraco-context>=6.0.1",
-    "jaraco-functools>=4.3.0",
-    "keyring>=25.6.0",
-    "markdown-it-py>=4.0.0",
-    "mdurl>=0.1.2",
-    "more-itertools>=10.8.0",
-    "mypy>=1.18.2",
-    "mypy-extensions>=1.1.0",
-    "nh3>=0.3.0",
-    "packaging>=25.0",
-    "pathspec>=0.12.1",
-    "pluggy>=1.6.0",
-    "py4j>=0.10.9.9",
-    "pygments>=2.19.2",
-    "pyproject-hooks>=1.2.0",
     "pyspark>=4.0.0",
-    "pytest>=8.4.2",
-    "pytest-cov>=7.0.0",
     "python-dateutil>=2.9.0.post0",
-    "readme-renderer>=44.0",
-    "requests>=2.32.5",
-    "requests-toolbelt>=1.0.0",
-    "rfc3986>=2.0.0",
-    "rich>=14.1.0",
-    "ruff>=0.13.1",
-    "six>=1.17.0",
-    "twine>=6.2.0",
-    "types-python-dateutil>=2.9.0.20250822",
-    "typing-extensions>=4.15.0",
-    "urllib3>=2.5.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shardate"
-version = "2025.9.9.4"
+version = "2025.9.20.3"
 description = "A lightweight Python library for efficiently reading year-month-day partitioned Parquet datasets."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "shardate"
 version = "2025.9.20.3"
 description = "A lightweight Python library for efficiently reading year-month-day partitioned Parquet datasets."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 authors = [
     {name = "Yoichi Ojima", email = "yoichiojima@gmail.com"}
 ]
@@ -16,8 +16,45 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "build>=1.3.0",
+    "certifi>=2025.8.3",
+    "charset-normalizer>=3.4.3",
+    "coverage>=7.10.6",
+    "docutils>=0.22.1",
+    "id>=1.5.0",
+    "idna>=3.10",
+    "iniconfig>=2.1.0",
+    "jaraco-classes>=3.4.0",
+    "jaraco-context>=6.0.1",
+    "jaraco-functools>=4.3.0",
+    "keyring>=25.6.0",
+    "markdown-it-py>=4.0.0",
+    "mdurl>=0.1.2",
+    "more-itertools>=10.8.0",
+    "mypy>=1.18.2",
+    "mypy-extensions>=1.1.0",
+    "nh3>=0.3.0",
+    "packaging>=25.0",
+    "pathspec>=0.12.1",
+    "pluggy>=1.6.0",
+    "py4j>=0.10.9.9",
+    "pygments>=2.19.2",
+    "pyproject-hooks>=1.2.0",
     "pyspark>=4.0.0",
+    "pytest>=8.4.2",
+    "pytest-cov>=7.0.0",
     "python-dateutil>=2.9.0.post0",
+    "readme-renderer>=44.0",
+    "requests>=2.32.5",
+    "requests-toolbelt>=1.0.0",
+    "rfc3986>=2.0.0",
+    "rich>=14.1.0",
+    "ruff>=0.13.1",
+    "six>=1.17.0",
+    "twine>=6.2.0",
+    "types-python-dateutil>=2.9.0.20250822",
+    "typing-extensions>=4.15.0",
+    "urllib3>=2.5.0",
 ]
 
 [project.urls]

--- a/src/shardate/shardate.py
+++ b/src/shardate/shardate.py
@@ -24,9 +24,7 @@ class Shardate:
         return spark_session().read.options(basePath=self.path).parquet
 
     def read_by_date(self, target_date: date) -> DataFrame:
-        return self.read(
-            f"{self.path}/{target_date.strftime(self.partition_format)}"
-        )
+        return self.read(f"{self.path}/{target_date.strftime(self.partition_format)}")
 
     def read_between(self, start_date: date, end_date: date) -> DataFrame:
         return self.read(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,8 @@
 """Tests for shardate.__init__ module."""
+
+import importlib
 import importlib.metadata
+import sys
 import unittest.mock
 
 
@@ -7,8 +10,8 @@ def test_version_with_package_not_found_error():
     """Test version handling when PackageNotFoundError is raised."""
     # Test the version retrieval logic directly without module reloading
     with unittest.mock.patch(
-        'importlib.metadata.version',
-        side_effect=importlib.metadata.PackageNotFoundError()
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError(),
     ):
         try:
             version = importlib.metadata.version("shardate")
@@ -20,12 +23,44 @@ def test_version_with_package_not_found_error():
 def test_version_with_valid_package():
     """Test version retrieval when package is found."""
     # Test the version retrieval logic directly without module reloading
-    with unittest.mock.patch(
-        'importlib.metadata.version',
-        return_value="1.2.3"
-    ):
+    with unittest.mock.patch("importlib.metadata.version", return_value="1.2.3"):
         try:
             version = importlib.metadata.version("shardate")
         except importlib.metadata.PackageNotFoundError:
             version = "unknown"
         assert version == "1.2.3"
+
+
+def test_init_module_with_package_not_found_error():
+    """Test __init__.py lines 9-10 by importing module with mocked PackageNotFoundError."""
+    # Remove the module from cache if it exists
+    module_name = "shardate"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    # Mock importlib.metadata.version to raise PackageNotFoundError
+    with unittest.mock.patch(
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError(),
+    ):
+        # Import the module, which will execute the try/except block
+        import shardate
+
+        # Verify that __version__ was set to "unknown" (line 10)
+        assert shardate.__version__ == "unknown"
+
+
+def test_init_module_with_valid_version():
+    """Test __init__.py with successful version retrieval."""
+    # Remove the module from cache if it exists
+    module_name = "shardate"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    # Mock importlib.metadata.version to return a version
+    with unittest.mock.patch("importlib.metadata.version", return_value="1.2.3"):
+        # Import the module, which will execute the try block
+        import shardate
+
+        # Verify that __version__ was set to the mocked version
+        assert shardate.__version__ == "1.2.3"

--- a/tests/test_shardate.py
+++ b/tests/test_shardate.py
@@ -92,6 +92,10 @@ def test_read_eoms_between(path: str, start_date: date, end_date: date):
 def test_spark_session_no_active_session():
     """Test spark_session function raises RuntimeError when no active session."""
     # Mock SparkSession.getActiveSession to return None
-    with unittest.mock.patch('shardate.shardate.SparkSession.getActiveSession', return_value=None):
-        with pytest.raises(RuntimeError, match="No active SparkSession found. Please create one."):
+    with unittest.mock.patch(
+        "shardate.shardate.SparkSession.getActiveSession", return_value=None
+    ):
+        with pytest.raises(
+            RuntimeError, match="No active SparkSession found. Please create one."
+        ):
             spark_session()


### PR DESCRIPTION
This pull request includes minor version updates and improvements to the test suite for the `shardate` library. The changes focus on refining the test coverage for version retrieval logic and improving code formatting for clarity and consistency.

**Versioning and metadata:**

* Updated the package version in `pyproject.toml` to `2025.9.20.3`.

**Testing improvements:**

* Added new tests in `tests/test_init.py` to verify the behavior of `shardate.__init__` when the package version is found or not found, including module import scenarios and cache handling.
* Improved formatting and consistency in existing tests in `tests/test_init.py` and `tests/test_shardate.py`, including the use of double quotes and expanded multi-line `with` statements for better readability. [[1]](diffhunk://#diff-056c6b0b13b9539a120e8832b32e9cf5e681eb230fda35a261267d6381a0599eR2-R14) [[2]](diffhunk://#diff-700617ba392a71008690d43afd8707e7f905ca99027c138bf40bab14b0d634dfL95-R100)

**Code formatting:**

* Minor formatting adjustment in the `read_by_date` method in `src/shardate/shardate.py` for improved clarity.