### PR TITLE
Release/v2025.9.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shardate"
-version = "2025.9.9.4"
+version = "2025.9.20"
 description = "A lightweight Python library for efficiently reading year-month-day partitioned Parquet datasets."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/shardate/shardate.py
+++ b/src/shardate/shardate.py
@@ -24,9 +24,7 @@ class Shardate:
         return spark_session().read.options(basePath=self.path).parquet
 
     def read_by_date(self, target_date: date) -> DataFrame:
-        return self.read(
-            f"{self.path}/{target_date.strftime(self.partition_format)}"
-        )
+        return self.read(f"{self.path}/{target_date.strftime(self.partition_format)}")
 
     def read_between(self, start_date: date, end_date: date) -> DataFrame:
         return self.read(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,8 @@
 """Tests for shardate.__init__ module."""
+
+import importlib
 import importlib.metadata
+import sys
 import unittest.mock
 
 
@@ -7,8 +10,8 @@ def test_version_with_package_not_found_error():
     """Test version handling when PackageNotFoundError is raised."""
     # Test the version retrieval logic directly without module reloading
     with unittest.mock.patch(
-        'importlib.metadata.version',
-        side_effect=importlib.metadata.PackageNotFoundError()
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError(),
     ):
         try:
             version = importlib.metadata.version("shardate")
@@ -20,12 +23,44 @@ def test_version_with_package_not_found_error():
 def test_version_with_valid_package():
     """Test version retrieval when package is found."""
     # Test the version retrieval logic directly without module reloading
-    with unittest.mock.patch(
-        'importlib.metadata.version',
-        return_value="1.2.3"
-    ):
+    with unittest.mock.patch("importlib.metadata.version", return_value="1.2.3"):
         try:
             version = importlib.metadata.version("shardate")
         except importlib.metadata.PackageNotFoundError:
             version = "unknown"
         assert version == "1.2.3"
+
+
+def test_init_module_with_package_not_found_error():
+    """Test __init__.py lines 9-10 by importing module with mocked PackageNotFoundError."""
+    # Remove the module from cache if it exists
+    module_name = "shardate"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    # Mock importlib.metadata.version to raise PackageNotFoundError
+    with unittest.mock.patch(
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError(),
+    ):
+        # Import the module, which will execute the try/except block
+        import shardate
+
+        # Verify that __version__ was set to "unknown" (line 10)
+        assert shardate.__version__ == "unknown"
+
+
+def test_init_module_with_valid_version():
+    """Test __init__.py with successful version retrieval."""
+    # Remove the module from cache if it exists
+    module_name = "shardate"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    # Mock importlib.metadata.version to return a version
+    with unittest.mock.patch("importlib.metadata.version", return_value="1.2.3"):
+        # Import the module, which will execute the try block
+        import shardate
+
+        # Verify that __version__ was set to the mocked version
+        assert shardate.__version__ == "1.2.3"

--- a/tests/test_shardate.py
+++ b/tests/test_shardate.py
@@ -92,6 +92,10 @@ def test_read_eoms_between(path: str, start_date: date, end_date: date):
 def test_spark_session_no_active_session():
     """Test spark_session function raises RuntimeError when no active session."""
     # Mock SparkSession.getActiveSession to return None
-    with unittest.mock.patch('shardate.shardate.SparkSession.getActiveSession', return_value=None):
-        with pytest.raises(RuntimeError, match="No active SparkSession found. Please create one."):
+    with unittest.mock.patch(
+        "shardate.shardate.SparkSession.getActiveSession", return_value=None
+    ):
+        with pytest.raises(
+            RuntimeError, match="No active SparkSession found. Please create one."
+        ):
             spark_session()


### PR DESCRIPTION
This pull request updates the `shardate` library with minor versioning changes, code style improvements, and expanded test coverage for version retrieval and error handling. The most important changes are grouped below:

**Versioning Update:**
* Updated the library version in `pyproject.toml` from `2025.9.9.4` to `2025.9.20`.

**Code Style and Consistency:**
* Minor formatting improvements in the `read_by_date` method for better readability in `src/shardate/shardate.py`.
* Improved code formatting for mocking and error assertion in the Spark session test in `tests/test_shardate.py`.

**Test Coverage Enhancements:**
* Added new tests in `tests/test_init.py` to verify `shardate.__init__` version retrieval logic, including cases for both successful retrieval and `PackageNotFoundError` handling.
* Refactored existing tests for version retrieval to use consistent mocking and assertion styles in `tests/test_init.py`.