### PR TITLE
feat: Add partition discovery, latest read, and missing partition handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ pip install shardate
 
 - **Date-based reading**: Read data for specific dates, date ranges, or collections of dates
 - **End-of-month support**: Dedicated functionality for reading end-of-month data
+- **Partition discovery**: Find available partitions within a date range
+- **Latest partition**: Automatically find and read the most recent available data
+- **Missing partition handling**: Skip missing partitions gracefully with warnings
 - **Flexible partitioning**: Customizable partition format (defaults to `y=%Y/m=%m/d=%d`)
 - **PySpark integration**: Seamlessly works with existing PySpark workflows
 - **Type hints**: Full type annotation support for better development experience
-- **Well-tested**: Comprehensive test suite ensuring reliability
 
 ## Quick Start
 
@@ -51,6 +53,34 @@ df = reader.read_by_dates(target_dates)
 
 # Read only end-of-month data within a date range
 df = reader.read_eoms_between(date(2025, 1, 1), date(2025, 3, 31))
+```
+
+### Handling Missing Partitions
+
+```python
+# Skip missing partitions instead of failing (useful for incomplete data)
+reader = Shardate("/path/to/data", skip_missing=True)
+
+# This will read available partitions and warn about missing ones
+df = reader.read_between(date(2025, 1, 1), date(2025, 1, 31))
+# Warning: Skipping 5 missing partitions: 2025-01-10 to 2025-01-14
+```
+
+### Partition Discovery
+
+```python
+# Find which dates have data (useful for debugging data gaps)
+reader = Shardate("/path/to/data")
+available = reader.list_available_dates(date(2025, 1, 1), date(2025, 1, 31))
+# [date(2025, 1, 1), date(2025, 1, 2), ..., date(2025, 1, 31)]
+```
+
+### Read Latest Available Data
+
+```python
+# Automatically find and read the most recent partition
+reader = Shardate("/path/to/data")
+df = reader.read_latest(lookback_days=30)  # Searches up to 30 days back
 ```
 
 ### Custom Partition Format
@@ -88,14 +118,19 @@ df.filter(df.column_name == "some_value").count()
 class Shardate:
     path: str
     partition_format: str = "y=%Y/m=%m/d=%d"
+    skip_missing: bool = False  # Skip missing partitions with warning
 ```
 
 #### Methods
 
-- `read_by_date(target_date: date) -> DataFrame`: Read data for a specific date
-- `read_between(start_date: date, end_date: date) -> DataFrame`: Read data between two dates (inclusive)  
-- `read_by_dates(target_dates: Iterable[date]) -> DataFrame`: Read data for specific dates
-- `read_eoms_between(start_date: date, end_date: date) -> DataFrame`: Read end-of-month data within a date range
+| Method | Description |
+|--------|-------------|
+| `read_by_date(target_date)` | Read data for a specific date |
+| `read_between(start_date, end_date)` | Read data between two dates (inclusive) |
+| `read_by_dates(target_dates)` | Read data for specific dates |
+| `read_eoms_between(start_date, end_date)` | Read end-of-month data within a date range |
+| `read_latest(lookback_days=30)` | Read the most recent available partition |
+| `list_available_dates(start_date, end_date)` | Discover which partitions exist in a range |
 
 ## Data Structure Requirements
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ df = reader.read_between(date(2025, 1, 1), date(2025, 1, 31))
 # Find which dates have data (useful for debugging data gaps)
 reader = Shardate("/path/to/data")
 available = reader.list_available_dates(date(2025, 1, 1), date(2025, 1, 31))
-# [date(2025, 1, 1), date(2025, 1, 2), ..., date(2025, 1, 31)]
+# [date(2025, 1, 1), date(2025, 1, 2), date(2025, 1, 5), ...]  # Shows gaps
 ```
 
 ### Read Latest Available Data

--- a/src/shardate/shardate.py
+++ b/src/shardate/shardate.py
@@ -1,9 +1,12 @@
 from datetime import date
+import warnings
 from typing import Iterable, Callable, Any
+from dataclasses import dataclass, field
+from pathlib import Path
 
+from dateutil.relativedelta import relativedelta
 from pyspark.sql import SparkSession
 from pyspark.sql import DataFrame
-from dataclasses import dataclass
 
 from shardate.dates import all_dates_between, eoms_between
 
@@ -18,29 +21,140 @@ def spark_session() -> SparkSession:
 class Shardate:
     path: str
     partition_format: str = "y=%Y/m=%m/d=%d"
+    skip_missing: bool = field(default=False)
 
     @property
     def read(self) -> Callable[[Any], DataFrame]:
         return spark_session().read.options(basePath=self.path).parquet
 
-    def read_by_date(self, target_date: date) -> DataFrame:
-        return self.read(f"{self.path}/{target_date.strftime(self.partition_format)}")
+    def _partition_path(self, target_date: date) -> str:
+        return f"{self.path}/{target_date.strftime(self.partition_format)}"
 
-    def read_between(self, start_date: date, end_date: date) -> DataFrame:
-        return self.read(
-            *{
-                f"{self.path}/{dt.strftime(self.partition_format)}"
-                for dt in all_dates_between(start_date, end_date)
-            }
+    def _partition_exists(self, target_date: date) -> bool:
+        """Check if a partition exists for the given date."""
+        path = self._partition_path(target_date)
+        try:
+            fs = spark_session()._jvm.org.apache.hadoop.fs.FileSystem.get(
+                spark_session()._jsc.hadoopConfiguration()
+            )
+            return fs.exists(spark_session()._jvm.org.apache.hadoop.fs.Path(path))
+        except Exception:
+            # Fallback for local filesystem
+            return Path(path).exists()
+
+    def _filter_existing(self, dates: Iterable[date]) -> tuple[list[date], list[date]]:
+        """Split dates into existing and missing partitions."""
+        existing = []
+        missing = []
+        for dt in dates:
+            if self._partition_exists(dt):
+                existing.append(dt)
+            else:
+                missing.append(dt)
+        return existing, missing
+
+    def list_available_dates(self, start_date: date, end_date: date) -> list[date]:
+        """Discover which partitions exist within a date range.
+
+        Useful for debugging data availability issues or finding gaps.
+
+        Args:
+            start_date: Start of the date range (inclusive)
+            end_date: End of the date range (inclusive)
+
+        Returns:
+            List of dates that have existing partitions
+        """
+        existing, _ = self._filter_existing(all_dates_between(start_date, end_date))
+        return sorted(existing)
+
+    def read_latest(self, lookback_days: int = 30) -> DataFrame:
+        """Read the most recent available partition.
+
+        Searches backwards from today to find the latest available data.
+
+        Args:
+            lookback_days: Maximum number of days to search backwards (default: 30)
+
+        Returns:
+            DataFrame from the most recent available partition
+
+        Raises:
+            FileNotFoundError: If no partition found within lookback window
+        """
+        from datetime import datetime
+        today = datetime.now().date()
+
+        for days_back in range(lookback_days + 1):
+            check_date = today - relativedelta(days=days_back)
+            if self._partition_exists(check_date):
+                return self.read_by_date(check_date)
+
+        raise FileNotFoundError(
+            f"No partition found within {lookback_days} days of {today}"
         )
+
+    def read_by_date(self, target_date: date) -> DataFrame:
+        return self.read(self._partition_path(target_date))
+
+    def read_between(
+        self, start_date: date, end_date: date
+    ) -> DataFrame:
+        """Read data between two dates (inclusive).
+
+        Args:
+            start_date: Start date (inclusive)
+            end_date: End date (inclusive)
+
+        Returns:
+            DataFrame containing data from all partitions in the range
+
+        Note:
+            If skip_missing=True, missing partitions are skipped with a warning.
+            If skip_missing=False (default), raises an error for missing partitions.
+        """
+        all_dates = list(all_dates_between(start_date, end_date))
+
+        if self.skip_missing:
+            existing, missing = self._filter_existing(all_dates)
+            if missing:
+                warnings.warn(
+                    f"Skipping {len(missing)} missing partitions: "
+                    f"{missing[0]} to {missing[-1]}"
+                )
+            if not existing:
+                raise FileNotFoundError(
+                    f"No partitions found between {start_date} and {end_date}"
+                )
+            paths = {self._partition_path(dt) for dt in existing}
+        else:
+            paths = {self._partition_path(dt) for dt in all_dates}
+
+        return self.read(*paths)
 
     def read_by_dates(self, target_dates: Iterable[date]) -> DataFrame:
-        return self.read(
-            *{
-                f"{self.path}/{dt.strftime(self.partition_format)}"
-                for dt in target_dates
-            }
-        )
+        """Read data for specific dates.
+
+        Args:
+            target_dates: Iterable of dates to read
+
+        Returns:
+            DataFrame containing data from all specified partitions
+        """
+        dates_list = list(target_dates)
+
+        if self.skip_missing:
+            existing, missing = self._filter_existing(dates_list)
+            if missing:
+                warnings.warn(f"Skipping {len(missing)} missing partitions")
+            if not existing:
+                raise FileNotFoundError("No partitions found for specified dates")
+            paths = {self._partition_path(dt) for dt in existing}
+        else:
+            paths = {self._partition_path(dt) for dt in dates_list}
+
+        return self.read(*paths)
 
     def read_eoms_between(self, start_date: date, end_date: date) -> DataFrame:
+        """Read end-of-month data within a date range."""
         return self.read_by_dates(eoms_between(start_date, end_date))


### PR DESCRIPTION
## Summary

- **`list_available_dates(start, end)`**: Discover which partitions exist within a date range. Useful for debugging data availability issues.
- **`read_latest(lookback_days=30)`**: Automatically find and read the most recent available partition.
- **`skip_missing=True`**: Skip missing partitions gracefully with warnings instead of failing.

## Why

These features address common production pain points:
- Debugging why data is missing for certain dates
- Building resilient pipelines that handle incomplete data  
- Finding latest data without knowing exact dates

## Example Usage

```python
reader = Shardate("/path/to/data", skip_missing=True)

# Find what data exists
available = reader.list_available_dates(date(2025, 1, 1), date(2025, 1, 31))

# Read latest available
df = reader.read_latest(lookback_days=7)

# Read range, skipping gaps
df = reader.read_between(date(2025, 1, 1), date(2025, 1, 31))
# Warning: Skipping 5 missing partitions...
```

## Test plan

- [x] All existing tests pass (12/12)
- [x] Lint passes
- [ ] Manual test with real partitioned data